### PR TITLE
Handle zero object maps by defaulting acc to 100%

### DIFF
--- a/Difficalcy.PerformancePlus/Services/OsuCalculatorService.cs
+++ b/Difficalcy.PerformancePlus/Services/OsuCalculatorService.cs
@@ -143,6 +143,9 @@ namespace Difficalcy.PerformancePlus.Services
             var countMiss = statistics[HitResult.Miss];
             var total = countGreat + countOk + countMeh + countMiss;
 
+            if (total == 0)
+                return 1;
+
             return (double)((6 * countGreat) + (2 * countOk) + countMeh) / (6 * total);
         }
 


### PR DESCRIPTION
## Why?

Currently this results in a NaN due to the division by zero.
100% was chosen instead of 0% as this is consistent with how the new osu site handles such cases.
For example https://osu.ppy.sh/beatmapsets/371675#taiko/814198

## Changes

- Default to 100% accuracy if a score has zero objects