### PR TITLE
Add branch to calculator package name

### DIFF
--- a/Difficalcy.PerformancePlus/Services/OsuCalculatorService.cs
+++ b/Difficalcy.PerformancePlus/Services/OsuCalculatorService.cs
@@ -35,7 +35,7 @@ namespace Difficalcy.PerformancePlus.Services
         {
             get
             {
-                var packageName = "https://github.com/Syriiin/osu";
+                var packageName = "https://github.com/Syriiin/osu/tree/performanceplus";
                 return new CalculatorInfo
                 {
                     RulesetName = OsuRuleset.Description,


### PR DESCRIPTION
## Why?

While the repo + commit hash does uniquely target the exact calc version, if using the calc package as a unique identifier for a calculator engine, as we do in osuchan, then we won't be able to support multiple calc branches per repo.

## Changes

- Add git branch to package name