### PR TITLE
Config renovate to auto-rebase

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,19 @@
     "config:recommended",
     "schedule:weekly"
   ],
+  "rebaseWhen": "behind-base-branch",
+  "packageRules": [
+    {
+      "matchManagers": [
+        "nuget"
+      ],
+      "matchPackageNames": [
+        "xunit*",
+        "Microsoft.Net.Test.Sdk"
+      ],
+      "groupName": "test-tools"
+    }
+  ],
   "git-submodules": {
     "enabled": true
   }


### PR DESCRIPTION
## Why?

Renovate is supposed to do this anyway since the repo rules require up-to-date branches before merge, but it seems it doesn't understand the new github rulesets, only the old branch rules.

## Changes

- Set `rebaseWhen` to `behind-base-branch`